### PR TITLE
Breeze client does not update the concurrent properties in case the data type is Binary

### DIFF
--- a/breeze-sequelize/src/SequelizeSaveHandler.js
+++ b/breeze-sequelize/src/SequelizeSaveHandler.js
@@ -269,7 +269,12 @@ ctor.prototype._saveEntityAsync = function(entityInfo, sqModel, transaction) {
 
     if (entityType.concurrencyProperties && entityType.concurrencyProperties.length > 0) {
       entityType.concurrencyProperties.forEach(function (cp) {
-        whereHash[cp.nameOnServer] = entityAspect.originalValuesMap[cp.nameOnServer];
+        // this is consistent with the client behaviour where it does not update the version property
+        // if its data type is binary
+        if (cp.dataType.name === 'Binary')
+          whereHash[cp.nameOnServer] = entity[cp.nameOnServer];
+        else
+          whereHash[cp.nameOnServer] = entityAspect.originalValuesMap[cp.nameOnServer];
       });
     }
     var setHash;


### PR DESCRIPTION
So (in this case) lets get it from current value instead of original value. 
This is a possible fix for issue #30