### PR TITLE
Fix for inlineCountEnabled and no rows result

### DIFF
--- a/breeze-sequelize/src/SequelizeQuery.ts
+++ b/breeze-sequelize/src/SequelizeQuery.ts
@@ -251,7 +251,7 @@ export class SequelizeQuery {
       return this._reshapeSelectResults(sqResults);
     }
     let inlineCount;
-    if (this.entityQuery.inlineCountEnabled && (sqResults as CountModel).count) {
+    if (this.entityQuery.inlineCountEnabled) {
       inlineCount = (sqResults as CountModel).count;
       sqResults = (sqResults as CountModel).rows;
     }


### PR DESCRIPTION
I found that when executing a query with inlineCountEnabled and skip,take but with no data results then we got an error on sqResult.map